### PR TITLE
add functionality to see registered tags

### DIFF
--- a/src/tag.ts
+++ b/src/tag.ts
@@ -108,10 +108,27 @@ export class Tag implements ToCBOR, Decodeable {
    * @param tag Tag number.
    * @returns Old decoder, if there was one.
    */
-  public static clearDecoder(tag: number): TagDecoder | undefined {
+  public static clearDecoder(tag: TagNumber): TagDecoder | undefined {
     const old = this.#tags.get(tag);
     this.#tags.delete(tag);
     return old;
+  }
+
+  /**
+   * Get the decoder for a given tag number.
+   *
+   * @param tag The tag number.
+   * @returns The decoder function, if there is one.
+   */
+  public static getDecoder(tag: TagNumber): TagDecoder | undefined {
+    return this.#tags.get(tag);
+  }
+
+  /**
+   * Get all registered decoders as object
+   */
+  public static getAllDecoders() {
+    return Object.fromEntries(this.#tags);
   }
 
   /**

--- a/test/tag.test.js
+++ b/test/tag.test.js
@@ -27,3 +27,32 @@ test('Tag', () => {
 
   assert.deepEqual([...t], ['2023-07-21T22:16:20-0600']);
 });
+
+test('Tag Register and verify decoders', () => {
+  function myDecoder(_tag) {
+    return 'myDecoder';
+  }
+
+  // Register a decoder with a tag
+  const t0 = Tag.registerDecoder(9999, myDecoder);
+
+  // Verify the we added decoder to the registry
+  assert.equal(Tag.getDecoder(9999), myDecoder);
+
+  // Verify execution is the same as the decoder
+  assert.equal(Tag.getDecoder(9999)(), myDecoder());
+
+  // Verify decoder is in all decoder list
+  const allDecoders = Tag.getAllDecoders();
+  assert.equal(allDecoders[9999], myDecoder);
+
+  // Remove the decoder from the registry
+  Tag.clearDecoder(9999);
+
+  // Verify the decoder is removed
+  assert.equal(Tag.getDecoder(9999), undefined);
+
+  // Verify the decoder is removed from all decoder list
+  assert.equal(Tag.getAllDecoders()[9999], undefined);
+});
+


### PR DESCRIPTION
Added functionality to show all registered decoders and tags in the registry.

We need this functionality as part of our BC-UR registry https://github.com/ngraveio/bc-ur/tree/feature/bc-ur-v2