### PR TITLE
Low-level sequence decoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
       "name": "İrfan Bilaloğlu",
       "email": "irfanbilaloglu@gmail.com",
       "url": "https://github.com/irfan798"
+    },
+    {
+      "name": "Mark Wubben",
+      "url": "https://novemberborn.net"
     }
   ],
   "license": "MIT",

--- a/src/decodeStream.ts
+++ b/src/decodeStream.ts
@@ -80,6 +80,23 @@ export class DecodeStream implements Sliceable {
     }
   }
 
+  /**
+   * Get a stream of events describing all CBOR items in the input.  Yields
+   * Value tuples.
+   *
+   * Note that this includes items indicating the start of an array or map, and
+   * the end of an indefinite-length item, and tag numbers separate from the tag
+   * content. Does not validate whether the input is a valid CBOR item.
+   *
+   * @throws On insufficient data.
+   * @example
+   * ```js
+   * const s = new DecodeStream(buffer);
+   * for (const [majorType, additionalInfo, value] of s.seq()) {
+   *  ...
+   * }
+   * ```
+   */
   public *seq(): ValueGenerator {
     while (this.#offset < this.#src.length) {
       yield *this.#nextVal(0);

--- a/src/decodeStream.ts
+++ b/src/decodeStream.ts
@@ -86,7 +86,11 @@ export class DecodeStream implements Sliceable {
    *
    * Note that this includes items indicating the start of an array or map, and
    * the end of an indefinite-length item, and tag numbers separate from the tag
-   * content. Does not validate whether the input is a valid CBOR item.
+   * content. Does not guarantee that the input is valid.
+   *
+   * Will attempt to read all items in an array or map, even if indefinite.
+   * Throws when there is insufficient data to do so. The same applies when
+   * reading tagged items, byte strings and text strings.
    *
    * @throws On insufficient data.
    * @example
@@ -106,6 +110,9 @@ export class DecodeStream implements Sliceable {
     // next item to be.
     //
     // Note that since we're producting each item, we don't need to track depth.
+    //
+    // Note that #nextVal takes care of reading array and map items and tag
+    // content, which means this can still throw if there is insufficient data.
     while (this.#offset < this.#src.length) {
       yield *this.#nextVal(0);
     }

--- a/src/decodeStream.ts
+++ b/src/decodeStream.ts
@@ -80,6 +80,12 @@ export class DecodeStream implements Sliceable {
     }
   }
 
+  public *seq(): ValueGenerator {
+    while (this.#offset < this.#src.length) {
+      yield *this.#nextVal(0);
+    }
+  }
+
   /**
    * Get the next CBOR value from the input stream.  Yields Value tuples.
    *

--- a/src/decodeStream.ts
+++ b/src/decodeStream.ts
@@ -98,6 +98,14 @@ export class DecodeStream implements Sliceable {
    * ```
    */
   public *seq(): ValueGenerator {
+    // Repeatedly read the next value from the input, until the offset of the
+    // next possible value is past the input length.
+    //
+    // Throws if their is insufficient data to read the next value. Otherwise,
+    // within #nextVal the offset will be incremented to where it expects the
+    // next item to be.
+    //
+    // Note that since we're producting each item, we don't need to track depth.
     while (this.#offset < this.#src.length) {
       yield *this.#nextVal(0);
     }

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,4 +1,4 @@
-import type {DecodeOptions, Parent, MtAiValue as Tuple} from './options.js';
+import type {DecodeOptions, MtAiValue, Parent} from './options.js';
 import {DecodeStream, type ValueGenerator} from './decodeStream.js';
 import {CBORcontainer} from './container.js';
 import {SYMS} from './constants.js';
@@ -73,14 +73,12 @@ export function decode<T = unknown>(
   return ret as T;
 }
 
-export {Tuple};
-
 /**
  * Decode CBOR Sequence bytes to major-type/additional-information/value tuples.
  */
 export class Sequence {
   #seq: ValueGenerator;
-  #peeked: Tuple | undefined;
+  #peeked: MtAiValue | undefined;
 
   public constructor(src: Uint8Array | string, options: DecodeOptions = {}) {
     const stream = new DecodeStream(src, normalizeOptions(options));
@@ -88,7 +86,7 @@ export class Sequence {
   }
 
   /** Peek at the next tuple, allowing for later reads. */
-  public peek(): Tuple | undefined {
+  public peek(): MtAiValue | undefined {
     if (!this.#peeked) {
       this.#peeked = this.#next();
     }
@@ -96,14 +94,14 @@ export class Sequence {
   }
 
   /** Read the next tuple. */
-  public read(): Tuple | undefined {
+  public read(): MtAiValue | undefined {
     const mav = this.#peeked ?? this.#next();
     this.#peeked = undefined;
     return mav;
   }
 
   /** Iterate over all tuples. */
-  public *[Symbol.iterator](): Generator<Tuple, void, undefined> {
+  public *[Symbol.iterator](): Generator<MtAiValue, void, undefined> {
     while (true) {
       const tuple = this.read();
 
@@ -115,7 +113,7 @@ export class Sequence {
     }
   }
 
-  #next(): Tuple | undefined {
+  #next(): MtAiValue | undefined {
     const {value: tuple, done} = this.#seq.next();
     if (done) {
       return undefined;

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -77,9 +77,13 @@ export function decode<T = unknown>(
  * Decode (a sequence of) CBOR bytes to
  * major-type/additional-information/value tuples.
  *
- * Note that this includes items indicating the start of an array or map, and
- * the end of an indefinite-length item, and tag numbers separate from the tag
- * content. Does not validate whether the input is a valid CBOR item.
+  * Note that this includes items indicating the start of an array or map, and
+  * the end of an indefinite-length item, and tag numbers separate from the tag
+  * content. Does not guarantee that the input is valid.
+  *
+  * Will attempt to read all items in an array or map, even if indefinite.
+  * Throws when there is insufficient data to do so. The same applies when
+  * reading tagged items, byte strings and text strings.
  *
  * @param src CBOR bytes to decode.
  * @param options Options for decoding.

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -74,7 +74,23 @@ export function decode<T = unknown>(
 }
 
 /**
- * Decode CBOR Sequence bytes to major-type/additional-information/value tuples.
+ * Decode (a sequence of) CBOR bytes to
+ * major-type/additional-information/value tuples.
+ *
+ * Note that this includes items indicating the start of an array or map, and
+ * the end of an indefinite-length item, and tag numbers separate from the tag
+ * content. Does not validate whether the input is a valid CBOR item.
+ *
+ * @param src CBOR bytes to decode.
+ * @param options Options for decoding.
+ * @throws {Error} On insufficient data.
+ * @example
+ * ```js
+ * const s = new Sequence(buffer);
+ * for (const [majorType, additionalInfo, value] of s.seq()) {
+ *  ...
+ * }
+ * ```
  */
 export class Sequence {
   #seq: ValueGenerator;

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,21 +1,11 @@
-import type {DecodeOptions, Parent} from './options.js';
+import type {DecodeOptions, Parent, MtAiValue as Tuple} from './options.js';
+import {DecodeStream, type ValueGenerator} from './decodeStream.js';
 import {CBORcontainer} from './container.js';
-import {DecodeStream} from './decodeStream.js';
 import {SYMS} from './constants.js';
 
-/**
- * Decode CBOR bytes to a JS value.
- *
- * @param src CBOR bytes to decode.
- * @param options Options for decoding.
- * @returns JS value decoded from cbor.
- * @throws {Error} No value found, decoding errors.
- */
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-export function decode<T = unknown>(
-  src: Uint8Array | string,
-  options: DecodeOptions = {}
-): T {
+function normalizeOptions(
+  options: DecodeOptions
+): Required<DecodeOptions> {
   const opts = {...CBORcontainer.defaultDecodeOptions};
   if (options.dcbor) {
     Object.assign(opts, CBORcontainer.dcborDecodeOptions);
@@ -31,6 +21,24 @@ export function decode<T = unknown>(
   if (opts.boxed) {
     opts.saveOriginal = true;
   }
+
+  return opts;
+}
+
+/**
+ * Decode CBOR bytes to a JS value.
+ *
+ * @param src CBOR bytes to decode.
+ * @param options Options for decoding.
+ * @returns JS value decoded from cbor.
+ * @throws {Error} No value found, decoding errors.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+export function decode<T = unknown>(
+  src: Uint8Array | string,
+  options: DecodeOptions = {}
+): T {
+  const opts = normalizeOptions(options);
   const stream = new DecodeStream(src, opts);
   let parent: Parent | undefined = undefined;
   let ret: unknown = undefined;
@@ -63,4 +71,56 @@ export function decode<T = unknown>(
     }
   }
   return ret as T;
+}
+
+export {Tuple};
+
+/**
+ * Decode CBOR Sequence bytes to major-type/additional-information/value tuples.
+ */
+export class Sequence {
+  #seq: ValueGenerator;
+  #peeked: Tuple | undefined;
+
+  public constructor(src: Uint8Array | string, options: DecodeOptions = {}) {
+    const stream = new DecodeStream(src, normalizeOptions(options));
+    this.#seq = stream.seq();
+  }
+
+  /** Peek at the next tuple, allowing for later reads. */
+  public peek(): Tuple | undefined {
+    if (!this.#peeked) {
+      this.#peeked = this.#next();
+    }
+    return this.#peeked;
+  }
+
+  /** Read the next tuple. */
+  public read(): Tuple | undefined {
+    const mav = this.#peeked ?? this.#next();
+    this.#peeked = undefined;
+    return mav;
+  }
+
+  /** Iterate over all tuples. */
+  public *[Symbol.iterator](): Generator<Tuple, void, undefined> {
+    while (true) {
+      const tuple = this.read();
+
+      if (!tuple) {
+        return;
+      }
+
+      yield tuple;
+    }
+  }
+
+  #next(): Tuple | undefined {
+    const {value: tuple, done} = this.#seq.next();
+    if (done) {
+      return undefined;
+    }
+
+    return tuple;
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export type {
   WriterOptions,
 } from './options.js';
 export {DiagnosticSizes} from './options.js';
-export {decode, Sequence, Tuple} from './decoder.js';
+export {decode, Sequence} from './decoder.js';
 export {diagnose} from './diagnostic.js';
 export {comment} from './comment.js';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export type {
   WriterOptions,
 } from './options.js';
 export {DiagnosticSizes} from './options.js';
-export {decode} from './decoder.js';
+export {decode, Sequence, Tuple} from './decoder.js';
 export {diagnose} from './diagnostic.js';
 export {comment} from './comment.js';
 export {

--- a/test/sequence.test.js
+++ b/test/sequence.test.js
@@ -1,0 +1,249 @@
+import '../lib/types.js';
+import {Sequence} from '../lib/decoder.js';
+import assert from 'node:assert/strict';
+import {hexToU8} from '../lib/utils.js';
+import test from 'node:test';
+
+test('Sequence constructor', () => {
+  // Test with Uint8Array input
+  const seq1 = new Sequence(hexToU8('0102')); // Two integers: 1, 2
+  assert.ok(seq1, 'Should create Sequence from Uint8Array');
+
+  // Test with hex string and explicit encoding
+  const seq2 = new Sequence('0102', {encoding: 'hex'}); // Two integers: 1, 2
+  assert.ok(seq2, 'Should create Sequence from hex string');
+});
+
+test('Sequence read and peek', () => {
+  // Simple sequence of two integers: 1, 2
+  // 01 -- Unsigned: 1
+  // 02 -- Unsigned: 2
+  const seq = new Sequence(hexToU8('0102'));
+
+  // Peek first tuple
+  const firstPeek = seq.peek();
+  assert.ok(firstPeek, 'Peek should return a tuple');
+  assert.equal(firstPeek[0], 0, 'Major type should be 0 (positive integer)');
+  assert.equal(firstPeek[2], 1, 'Value should be 1');
+
+  // Peek again should return the same tuple
+  const secondPeek = seq.peek();
+  assert.strictEqual(secondPeek, firstPeek, 'Multiple peeks should return same tuple');
+
+  // Read should return the same tuple and advance
+  const firstRead = seq.read();
+  assert.strictEqual(firstRead, firstPeek, 'Read should return same tuple as peek');
+
+  // Next read should get the second tuple
+  const secondRead = seq.read();
+  assert.ok(secondRead, 'Should read second tuple');
+  assert.equal(secondRead[0], 0, 'Major type should be 0 (positive integer)');
+  assert.equal(secondRead[2], 2, 'Value should be 2');
+
+  // No more tuples
+  assert.equal(seq.read(), undefined, 'Should return undefined when no more tuples');
+});
+
+test('Sequence iteration', () => {
+  // Sequence of three integers: 1, 2, 3
+  // 01 -- Unsigned: 1
+  // 02 -- Unsigned: 2
+  // 03 -- Unsigned: 3
+  const seq = new Sequence(hexToU8('010203'));
+
+  const values = [];
+  for (const tuple of seq) {
+    values.push(tuple[2]);
+  }
+
+  assert.deepEqual(values, [1, 2, 3], 'Should iterate through all values');
+
+  // Sequence should be exhausted
+  assert.equal(seq.peek(), undefined, 'Peek should return undefined after iteration');
+});
+
+test('Sequence with complex CBOR', () => {
+  // Sequence containing: 1, "hello", [1, 2, 3], 3
+  // 01       -- Unsigned: 1
+  // 65       -- UTF8 (Length: 5): "hello"
+  //   68656c6c6f
+  // 83       -- Array (Length: 3 items)
+  //   01     --   [0] Unsigned: 1
+  //   02     --   [1] Unsigned: 2
+  //   03     --   [2] Unsigned: 3
+  // 03       -- Unsigned: 3
+  const hex = '016568656c6c6f8301020303';
+  const seq = new Sequence(hex, {encoding: 'hex'});
+
+  const tuples = Array.from(seq);
+
+  // We should get 7 tuples in total
+  assert.equal(tuples.length, 7, 'Should have 7 tuples for this sequence');
+
+  // First tuple: 1
+  assert.equal(tuples[0][0], 0, 'First tuple should be unsigned integer type (0)');
+  assert.equal(tuples[0][2], 1, 'First value should be 1');
+
+  // Second tuple: string "hello"
+  assert.equal(tuples[1][0], 3, 'Second major type should be 3 (text string)');
+  assert.equal(tuples[1][2], 'hello', 'String value should be "hello"');
+
+  // Third tuple: array header with length 3
+  assert.equal(tuples[2][0], 4, 'Third major type should be 4 (array)');
+  assert.equal(tuples[2][2], 3, 'Array length should be 3');
+
+  // Array elements
+  assert.equal(tuples[3][2], 1, 'First array element should be 1');
+  assert.equal(tuples[4][2], 2, 'Second array element should be 2');
+  assert.equal(tuples[5][2], 3, 'Third array element should be 3');
+
+  // Final value: 3
+  assert.equal(tuples[6][2], 3, 'Last value should be 3');
+});
+
+test('Sequence with break code', () => {
+  // Integer 1 followed by BREAK code
+  // 01 -- Unsigned: 1
+  // FF -- BREAK
+  const hex = '01FF';
+  const seq = new Sequence(hexToU8(hex));
+
+  // First item should be readable
+  const firstTuple = seq.read();
+  assert.equal(firstTuple[2], 1, 'First item should be readable');
+
+  // Break code should be readable as a tuple
+  const breakTuple = seq.read();
+  assert.ok(breakTuple, 'Break code should be readable');
+  assert.equal(breakTuple[0], 7, 'Major type should be 7 for special values');
+  assert.equal(breakTuple[1], 31, 'Additional info should be 31 for break code');
+
+  // No more tuples
+  assert.equal(seq.read(), undefined, 'No more tuples after break code');
+});
+
+test('Incomplete array in sequence', () => {
+  // Array claiming length 2 but followed by a separate item
+  // 82    -- Array (Length: 2 items)
+  //   01  --   [0] Unsigned: 1
+  // 02    -- Unsigned: 2 (appears outside array)
+  const hex = '820102';
+  const seq = new Sequence(hexToU8(hex));
+
+  // First tuple should be the array header
+  const arrayHeader = seq.read();
+  assert.equal(arrayHeader[0], 4, 'First tuple should be array type');
+  assert.equal(arrayHeader[2], 2, 'Array length should be 2');
+
+  // Second tuple should be the first array item
+  const firstItem = seq.read();
+  assert.equal(firstItem[2], 1, 'First array item should be 1');
+
+  // Next tuple should be what looks like a second array item
+  // but is actually a separate sequence item
+  const nextItem = seq.read();
+  assert.equal(nextItem[2], 2, 'Next item should be 2');
+
+  // No more items
+  assert.equal(seq.read(), undefined, 'No more items after reading all bytes');
+});
+
+test('Empty sequence', () => {
+  // Empty byte sequence
+  const seq = new Sequence(hexToU8(''));
+  assert.equal(seq.peek(), undefined, 'Peek should return undefined for empty sequence');
+  assert.equal(seq.read(), undefined, 'Read should return undefined for empty sequence');
+  const tuples = Array.from(seq);
+  assert.equal(tuples.length, 0, 'Should have no tuples for empty sequence');
+});
+
+test('Indefinite length items in sequence', () => {
+  // Indefinite length array with 2 items followed by break
+  // 9F    -- Array (Length: Indefinite)
+  //   01  --   [0] Unsigned: 1
+  //   02  --   [1] Unsigned: 2
+  //   FF  --   [2] BREAK
+  const hex = '9f0102ff';
+  const seq = new Sequence(hexToU8(hex));
+
+  const tuples = Array.from(seq);
+  assert.equal(tuples.length, 4, 'Should have 4 tuples for indef array sequence');
+
+  assert.equal(tuples[0][0], 4, 'First tuple should be array type');
+  assert.equal(tuples[0][1], 31, 'Additional info should be 31 for indef length');
+
+  assert.equal(tuples[1][2], 1, 'First array item should be 1');
+  assert.equal(tuples[2][2], 2, 'Second array item should be 2');
+
+  assert.equal(tuples[3][0], 7, 'Fourth tuple should be special type');
+  assert.equal(tuples[3][1], 31, 'Additional info should be 31 for break');
+});
+
+test('Nested structures in sequence', () => {
+  // Nested array [[[1]]] followed by 2, 3
+  // 81      -- Array (Length: 1)
+  //   81    --   [0] Array (Length: 1)
+  //     81  --     [0] Array (Length: 1)
+  //       01 --       [0] Unsigned: 1
+  // 02      -- Unsigned: 2
+  // 03      -- Unsigned: 3
+  const hex = '818181010203';
+  const seq = new Sequence(hexToU8(hex));
+
+  const tuples = Array.from(seq);
+  assert.equal(tuples.length, 6, 'Should have 6 tuples including nested structures');
+
+  // Check the nesting structure
+  assert.equal(tuples[0][0], 4, 'First tuple should be array type');
+  assert.equal(tuples[0][2], 1, 'Outer array length should be 1');
+
+  assert.equal(tuples[1][0], 4, 'Second tuple should be array type');
+  assert.equal(tuples[1][2], 1, 'Middle array length should be 1');
+
+  assert.equal(tuples[2][0], 4, 'Third tuple should be array type');
+  assert.equal(tuples[2][2], 1, 'Inner array length should be 1');
+
+  assert.equal(tuples[3][2], 1, 'Inner value should be 1');
+
+  // Then come the individual integers from the sequence
+  assert.equal(tuples[4][2], 2, 'Next sequence item should be 2');
+  assert.equal(tuples[5][2], 3, 'Last sequence item should be 3');
+});
+
+test('Tagged values in sequence', () => {
+  // Tag 0 (date/time string) with "2023-01-01", followed by 2, 3
+  // C0          -- Tag #0: (String Date)
+  //   6A        --   UTF8 (Length: 10): "2023-01-01"
+  //     323032332d30312d3031
+  // 02          -- Unsigned: 2
+  // 03          -- Unsigned: 3
+  const hex = 'c06a323032332d30312d30310203';
+  const seq = new Sequence(hexToU8(hex));
+
+  const tuples = Array.from(seq);
+
+  // First tuple should be tag 0
+  assert.equal(tuples[0][0], 6, 'First tuple should be tag type');
+  assert.equal(tuples[0][2], 0, 'Tag value should be 0 (date/time)');
+
+  // Second tuple should be the string
+  assert.equal(tuples[1][0], 3, 'Second tuple should be string type');
+  assert.equal(tuples[1][2], '2023-01-01', 'String value should be "2023-01-01"');
+
+  // The remaining sequence items
+  assert.equal(tuples[2][2], 2, 'Third item should be 2');
+  assert.equal(tuples[3][2], 3, 'Fourth item should be 3');
+});
+
+test('Incomplete CBOR data', () => {
+  // String claiming length 10 but only 5 bytes provided
+  // 6A          -- UTF8 (Length: 10)
+  //   48656c6c6f -- "Hello" (only 5 bytes)
+  const hex = '6a48656c6c6f';
+  const seq = new Sequence(hexToU8(hex));
+
+  // Should throw when trying to read past available bytes
+  assert.throws(() => seq.read(), {
+    message: /Unexpected end of stream/,
+  }, 'Should throw when reading incomplete string');
+});

--- a/test/sequence.test.js
+++ b/test/sequence.test.js
@@ -4,16 +4,6 @@ import assert from 'node:assert/strict';
 import {hexToU8} from '../lib/utils.js';
 import test from 'node:test';
 
-test('Sequence constructor', () => {
-  // Test with Uint8Array input
-  const seq1 = new Sequence(hexToU8('0102')); // Two integers: 1, 2
-  assert.ok(seq1, 'Should create Sequence from Uint8Array');
-
-  // Test with hex string and explicit encoding
-  const seq2 = new Sequence('0102', {encoding: 'hex'}); // Two integers: 1, 2
-  assert.ok(seq2, 'Should create Sequence from hex string');
-});
-
 test('Sequence read and peek', () => {
   // Simple sequence of two integers: 1, 2
   // 01 -- Unsigned: 1
@@ -44,7 +34,25 @@ test('Sequence read and peek', () => {
   assert.equal(seq.read(), undefined, 'Should return undefined when no more tuples');
 });
 
-test('Sequence iteration', () => {
+test('Sequence iteration with Uint8Array input', () => {
+  // Sequence of three integers: 1, 2, 3
+  // 01 -- Unsigned: 1
+  // 02 -- Unsigned: 2
+  // 03 -- Unsigned: 3
+  const seq = new Sequence(new Uint8Array([1, 2, 3]));
+
+  const values = [];
+  for (const tuple of seq) {
+    values.push(tuple[2]);
+  }
+
+  assert.deepEqual(values, [1, 2, 3], 'Should iterate through all values');
+
+  // Sequence should be exhausted
+  assert.equal(seq.peek(), undefined, 'Peek should return undefined after iteration');
+});
+
+test('Sequence iteration with hex input', () => {
   // Sequence of three integers: 1, 2, 3
   // 01 -- Unsigned: 1
   // 02 -- Unsigned: 2


### PR DESCRIPTION
Allows low-level decoding of CBOR sequences, yielding tuples with major type, additional information & values.

Sequences can be iterated as is, but also supports peek() to look at the next value, and read() which consumes that value.

Fixes #70.

---

See usage in the `Decoder` in the very WIP Concordance rewrite. Current link: https://github.com/concordancejs/concordance/blob/b43859b9124fdbb15f657a8d9636183e83c59cf5/src/deserialize.ts#L52

This is very low-level, in fact I'm interpreting the major types etc by hand. I'm not dealing with indefinite length values either.

Mostly looking for feedback on whether this is worthwhile as a first approach.