### PR TITLE
High-level interface for CBOR Sequences. decodeSequence will return an iterator for all of the JS items in a sequence.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "cbor",
     "json",
     "rfc7049",
-    "rfc8949"
+    "rfc8949",
+    "rfc8742"
   ],
   "author": {
     "name": "Joe Hildebrand",

--- a/src/decodeStream.ts
+++ b/src/decodeStream.ts
@@ -60,7 +60,7 @@ export class DecodeStream implements Sliceable {
   /**
    * Get the chunk of this stream from the given position to the current offset.
    *
-   * @param begin Positiion to read from.  Should be <= current offset.
+   * @param begin Position to read from.  Should be <= current offset.
    * @returns Subarray of input stream (not copy).
    */
   public toHere(begin: number): Uint8Array {

--- a/src/decodeStream.ts
+++ b/src/decodeStream.ts
@@ -57,6 +57,12 @@ export class DecodeStream implements Sliceable {
     );
   }
 
+  /**
+   * Get the chunk of this stream from the given position to the current offset.
+   *
+   * @param begin Positiion to read from.  Should be <= current offset.
+   * @returns Subarray of input stream (not copy).
+   */
   public toHere(begin: number): Uint8Array {
     return subarrayRanges(this.#src, begin, this.#offset);
   }
@@ -81,8 +87,8 @@ export class DecodeStream implements Sliceable {
   }
 
   /**
-   * Get a stream of events describing all CBOR items in the input.  Yields
-   * Value tuples.
+   * Get a stream of events describing all CBOR items in the input CBOR Sequence
+   * consisting of multiple CBOR items. Yields Value tuples.
    *
    * Note that this includes items indicating the start of an array or map, and
    * the end of an indefinite-length item, and tag numbers separate from the tag
@@ -109,10 +115,12 @@ export class DecodeStream implements Sliceable {
     // within #nextVal the offset will be incremented to where it expects the
     // next item to be.
     //
-    // Note that since we're producting each item, we don't need to track depth.
+    // Note that since we're producing each item, we don't need to track depth.
     //
     // Note that #nextVal takes care of reading array and map items and tag
     // content, which means this can still throw if there is insufficient data.
+    //
+    // Note that #nextVal ALWAYS consumes at least one byte.
     while (this.#offset < this.#src.length) {
       yield *this.#nextVal(0);
     }

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -134,7 +134,7 @@ export class SequenceEvents {
   #peeked: MtAiValue | undefined;
 
   /**
-   * Create an Even
+   * Create an Event
    * @param src CBOR bytes to decode.
    * @param options Options for decoding.
    */

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,11 +1,16 @@
-import type {DecodeOptions, MtAiValue, Parent} from './options.js';
+import type {
+  DecodeOptions,
+  MtAiValue,
+  Parent,
+  RequiredDecodeOptions,
+} from './options.js';
 import {DecodeStream, type ValueGenerator} from './decodeStream.js';
 import {CBORcontainer} from './container.js';
 import {SYMS} from './constants.js';
 
 function normalizeOptions(
   options: DecodeOptions
-): Required<DecodeOptions> {
+): RequiredDecodeOptions {
   const opts = {...CBORcontainer.defaultDecodeOptions};
   if (options.dcbor) {
     Object.assign(opts, CBORcontainer.dcborDecodeOptions);
@@ -26,6 +31,61 @@ function normalizeOptions(
 }
 
 /**
+ * Internal state machine for turning a stream of MtAiValue tuples into
+ * a JS value.
+ */
+class StateMachine {
+  /**
+   * Top-most pending parent.
+   */
+  public parent: Parent | undefined = undefined;
+
+  /**
+   * If parent is undefined, the current value from the stream.
+   */
+  public ret: unknown = undefined;
+
+  /**
+   * Go to the next state based on the event.
+   *
+   * @param mav Next event to process
+   * @param opts Stream options
+   * @param stream Currently-reading stream.  Will be advanced.
+   */
+  public step(
+    mav: MtAiValue,
+    opts: RequiredDecodeOptions,
+    stream: DecodeStream
+  ): void {
+    this.ret = CBORcontainer.create(mav, this.parent, opts, stream);
+
+    if (mav[2] === SYMS.BREAK) {
+      if (this.parent?.isStreaming) {
+        this.parent.left = 0;
+      } else {
+        throw new Error('Unexpected BREAK');
+      }
+    } else if (this.parent) {
+      this.parent.push(this.ret, stream, mav[3]);
+    }
+
+    if (this.ret instanceof CBORcontainer) {
+      this.parent = this.ret;
+    }
+
+    // Convert all finished parents in the chain to the correct type, replacing
+    // in *their* parents as necessary.
+    while (this.parent?.done) {
+      this.ret = this.parent.convert(stream);
+
+      const p = this.parent.parent;
+      p?.replaceLast(this.ret, this.parent, stream);
+      this.parent = p;
+    }
+  }
+}
+
+/**
  * Decode CBOR bytes to a JS value.
  *
  * @param src CBOR bytes to decode.
@@ -40,54 +100,27 @@ export function decode<T = unknown>(
 ): T {
   const opts = normalizeOptions(options);
   const stream = new DecodeStream(src, opts);
-  let parent: Parent | undefined = undefined;
-  let ret: unknown = undefined;
+  const state = new StateMachine();
 
   for (const mav of stream) {
-    ret = CBORcontainer.create(mav, parent, opts, stream);
-
-    if (mav[2] === SYMS.BREAK) {
-      if (parent?.isStreaming) {
-        parent.left = 0;
-      } else {
-        throw new Error('Unexpected BREAK');
-      }
-    } else if (parent) {
-      parent.push(ret, stream, mav[3]);
-    }
-
-    if (ret instanceof CBORcontainer) {
-      parent = ret;
-    }
-
-    // Convert all finished parents in the chain to the correct type, replacing
-    // in *their* parents as necessary.
-    while (parent?.done) {
-      ret = parent.convert(stream);
-
-      const p = parent.parent;
-      p?.replaceLast(ret, parent, stream);
-      parent = p;
-    }
+    state.step(mav, opts, stream);
   }
-  return ret as T;
+  return state.ret as T;
 }
 
 /**
- * Decode (a sequence of) CBOR bytes to
- * major-type/additional-information/value tuples.
- *
+  * Decode the bytes of a CBOR Sequence to major-type/additional-information/
+  * value tuples.  Each of these tuples is an event in parsing the sequence.
+  *
   * Note that this includes items indicating the start of an array or map, and
-  * the end of an indefinite-length item, and tag numbers separate from the tag
-  * content. Does not guarantee that the input is valid.
+  * the end of an indefinite-length item, and tag numbers separate from the
+  * tag content. Does not guarantee that the input is valid.
   *
   * Will attempt to read all items in an array or map, even if indefinite.
   * Throws when there is insufficient data to do so. The same applies when
   * reading tagged items, byte strings and text strings.
  *
- * @param src CBOR bytes to decode.
- * @param options Options for decoding.
- * @throws {Error} On insufficient data.
+ * @see https://www.rfc-editor.org/rfc/rfc8742.html
  * @example
  * ```js
  * const s = new Sequence(buffer);
@@ -96,16 +129,25 @@ export function decode<T = unknown>(
  * }
  * ```
  */
-export class Sequence {
+export class SequenceEvents {
   #seq: ValueGenerator;
   #peeked: MtAiValue | undefined;
 
+  /**
+   * Create an Even
+   * @param src CBOR bytes to decode.
+   * @param options Options for decoding.
+   */
   public constructor(src: Uint8Array | string, options: DecodeOptions = {}) {
     const stream = new DecodeStream(src, normalizeOptions(options));
     this.#seq = stream.seq();
   }
 
-  /** Peek at the next tuple, allowing for later reads. */
+  /**
+   * Peek at the next tuple, allowing for later reads.
+   *
+   * @throws {Error} On insufficient data.
+   */
   public peek(): MtAiValue | undefined {
     if (!this.#peeked) {
       this.#peeked = this.#next();
@@ -113,14 +155,22 @@ export class Sequence {
     return this.#peeked;
   }
 
-  /** Read the next tuple. */
+  /**
+   * Read the next tuple.
+   *
+   * @throws {Error} On insufficient data.
+   */
   public read(): MtAiValue | undefined {
     const mav = this.#peeked ?? this.#next();
     this.#peeked = undefined;
     return mav;
   }
 
-  /** Iterate over all tuples. */
+  /**
+   * Iterate over all tuples.
+   *
+   * @throws {Error} On insufficient data.
+   */
   public *[Symbol.iterator](): Generator<MtAiValue, void, undefined> {
     while (true) {
       const tuple = this.read();
@@ -140,5 +190,29 @@ export class Sequence {
     }
 
     return tuple;
+  }
+}
+
+/**
+ * Decode a CBOR Sequence consisting of multiple CBOR items.
+ *
+ * @param src CBOR bytes to decode.
+ * @param options Options for decoding.
+ * @yields JS value decoded from CBOR sequence.
+ * @see https://www.rfc-editor.org/rfc/rfc8742.html
+ */
+export function *decodeSequence<T = unknown>(
+  src: Uint8Array | string,
+  options: DecodeOptions = {}
+): Generator<T, undefined, undefined> {
+  const opts = normalizeOptions(options);
+  const stream = new DecodeStream(src, opts);
+  const state = new StateMachine();
+
+  for (const mav of stream.seq()) {
+    state.step(mav, opts, stream);
+    if (!state.parent) {
+      yield state.ret as T;
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export type {
   WriterOptions,
 } from './options.js';
 export {DiagnosticSizes} from './options.js';
-export {decode, Sequence} from './decoder.js';
+export {decode, decodeSequence, SequenceEvents} from './decoder.js';
 export {diagnose} from './diagnostic.js';
 export {comment} from './comment.js';
 export {


### PR DESCRIPTION
Renamed Sequence to SequenceEvents to make it more
clear what was being returned and to make it match
decodeSequence.
